### PR TITLE
Script remove unused palette

### DIFF
--- a/ActEditor/ActEditor.csproj
+++ b/ActEditor/ActEditor.csproj
@@ -14,7 +14,6 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>

--- a/ActEditor/Core/ActEditorWindow.xaml.cs
+++ b/ActEditor/Core/ActEditorWindow.xaml.cs
@@ -65,16 +65,6 @@ namespace ActEditor.Core {
 
 		public ActEditorWindow()
 			: base("Act Editor", "app.ico", SizeToContent.WidthAndHeight, ResizeMode.CanResize) {
-			try {
-				Rsm rsm = new Rsm(@"C:\Users\Tokei\Downloads\6speedrun.rsm");
-
-				Z.F(rsm);
-			}
-			catch (Exception err) {
-				ErrorHandler.HandleException(err);
-			}
-
-
 
 			Instance = this;
 			Spr.EnableImageSizeCheck = false;

--- a/ActEditor/Resources/script12_remove_unused_palette.cs
+++ b/ActEditor/Resources/script12_remove_unused_palette.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using GRF.FileFormats.ActFormat;
+using GRF.Image;
+
+namespace Scripts {
+    public class Script : IActScript {
+        public object DisplayName {
+            get { return "Remove unused palette"; }
+        }
+
+        public string Group {
+            get { return "Scripts"; }
+        }
+
+        public string InputGesture {
+            get { return null; }
+        }
+
+        public string Image {
+            get { return "delete.png"; }
+        }
+
+        public void Execute(Act act, int selectedActionIndex, int selectedFrameIndex, int[] selectedLayerIndexes) {
+            if (act == null || act.Sprite == null || act.Sprite.Palette == null)
+                return;
+
+            HashSet<byte> usedIndexes = new HashSet<byte>();
+            foreach (var image in act.Sprite.Images) {
+                if (image.GrfImageType == GrfImageType.Indexed8) {
+                    foreach (byte idx in image.Pixels)
+                        usedIndexes.Add(idx);
+                }
+            }
+            byte[] palette = act.Sprite.Palette.BytePalette;
+            for (int i = 0; i < 256; i++) {
+                if (!usedIndexes.Contains((byte)i)) {
+                    palette[4 * i + 0] = 255;
+                    palette[4 * i + 1] = 0;
+                    palette[4 * i + 2] = 255;
+                    palette[4 * i + 3] = 255;
+                }
+            }
+            act.Sprite.Palette.SetPalette(palette);
+        }
+
+        public bool CanExecute(Act act, int selectedActionIndex, int selectedFrameIndex, int[] selectedLayerIndexes) {
+            return act != null && act.Sprite != null && act.Sprite.Palette != null;
+        }
+    }
+}

--- a/PaletteEditor/PaletteEditor.csproj
+++ b/PaletteEditor/PaletteEditor.csproj
@@ -12,7 +12,6 @@
     <AssemblyName>PaletteEditor</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>


### PR DESCRIPTION
- Identifies and removes unused palette entries
- Keeps structure consistent for ACT/Sprite usage
- Simplifies further editing and maintenance